### PR TITLE
Issue 39

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Running the unit tests is simple when using node! All you need to call inside th
 npm test
 ```
 
-> Note: each test must be passing before submitting a pull-request. Travis-CI will check unit tests before allowing admins to merge. More in [contributing](https://github.com/srepollock/divine-engine/blob/master/CONTRIBUTING.md)
+> Note: each test must be passing before submitting a pull-request. Travis-CI will check unit tests before allowing admins to merge. More in [contributing](https://github.com/srepollock/divine-engine/blob/master/.github/CONTRIBUTING.md)
 
 ### Break down into end to end tests
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Coding styles must be followed in this project. To ensure that users are followi
 
 ## Contributing
 
-Please read [CONTRIBUTING](https://github.com/srepollock/divine-engine/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING](https://github.com/srepollock/divine-engine/blob/master/.github/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Versioning
 


### PR DESCRIPTION
Fixes #39 :  broken links in README.md to the repository's CONTRIBUTING.md file.


## How to use
The two links with the link text "contributing", and "CONTRIBUTING" can be clicked and the user should now be redirected to CONTRIBUTING.md

## Not Fixed:

 There is also a link to CONTRIBUTING.md in the repo's [Your Project](https://github.com/srepollock/divine-engine/wiki/Your-Project) page that is broken (I don't have contributor permissions to modify the wiki)